### PR TITLE
references #4, procwrap sends stderr json to nsq

### DIFF
--- a/procwrap/__init__.py
+++ b/procwrap/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
 
-from .procwrap import procwrap
+from .procwrap import ProcessWrapper
 
-__all__ = ["procwrap"]
+__all__ = ["ProcessWrapper"]

--- a/procwrap/procwrap.py
+++ b/procwrap/procwrap.py
@@ -2,39 +2,157 @@
 
 import os
 import sys
+import time
+import requests
 import argparse
 import subprocess
 
-def procwrap(command, pid_file=None):
-    """
-    executes the process specified in args.command.
-    returns the returncode of the command.
-    """
-    if pid_file is not None:
-        d = os.path.dirname(pid_file)
-        if not os.path.exists(d):
-            os.makedirs(d)
+# what if this script fails somewhere.
+# say the nsq doesn't connect, etc.
+# we have to use local logging for this.
+import logging
+logging.basicConfig(
+    stream=sys.stderr,
+    datefmt="%Y-%m-%dT%H-%M-%S",
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger()
 
-    process = subprocess.Popen(command)
-    if pid_file is not None:
-        with open(pid_file, "w") as fp:
-            fp.write("%s" % process.pid)
+class ProcessWrapper(object):
+    _NSQD_HTTP_ADDRESS = "http://127.0.0.1:4151"
+    _NSQ_LOG_TOPIC = "log"
+    _DISABLE_NSQ = False
+    _PID_FILE = None
 
-    process.wait()
-    return process.returncode
+    def __init__(
+            self,
+            command,
+            pid_file=_PID_FILE,
+            disable_nsq=_DISABLE_NSQ,
+            nsq_log_topic=_NSQ_LOG_TOPIC,
+            nsqd_http_address=_NSQD_HTTP_ADDRESS):
+
+        self.command = command
+        self.pid_file = pid_file
+        self.disable_nsq = disable_nsq
+        self.nsq_log_topic = nsq_log_topic
+
+        nsqd_http_address = nsqd_http_address.rstrip('/')
+        if not nsqd_http_address.startswith("http://"):
+            nsqd_http_address = 'http://%s' % nsqd_http_address
+
+        self.nsqd_http_address = nsqd_http_address
+
+        self.process = None
+        self.write_to_nsq = lambda msg: None
+
+        if not self.disable_nsq:
+            self.init_nsq()
+
+    def init_nsq(self):
+        session = requests.Session()
+        # TODO use urljoin ?
+        response = None
+        try:
+            response = session.get("%s/ping" % self.nsqd_http_address)
+            if response.status_code != 200:
+                raise Exception("bad response %s" % response)
+        except:
+            logger.exception(
+                "if you wish to disable nsqd, use --disable-nsq"
+            )
+            sys.exit(-1)
+
+        # TODO nsq is a failure point for our logs. what do we do if nsq is down ?
+
+        url = "%s/pub" % self.nsqd_http_address
+        topic = self.nsq_log_topic
+        # TODO what if this write to nsq fails ?
+        self.write_to_nsq = lambda msg: session.post(url, data=msg, params={"topic": topic})
+
+    def start(self):
+        """
+        starts the command and blocks till it finishes.
+        once finished, returns the returncode.
+        """
+
+        if self.pid_file is not None:
+            d = os.path.dirname(self.pid_file)
+            if not os.path.exists(d):
+                os.makedirs(d)
+
+        # NOTE only capturing stderr. stdout still goes to tty.
+
+        self.process = subprocess.Popen(
+            self.command, bufsize=1, universal_newlines=True,
+            stderr=subprocess.PIPE,
+        )
+
+        if self.pid_file is not None:
+            with open(self.pid_file, "w") as fp:
+                fp.write("%s" % self.process.pid)
+
+        read_stderr_line = self.process.stderr.readline
+        poll = self.process.poll
+        # TODO buffering and sending many to nsq together ?
+        # TODO avoid
+        while poll() is None:
+            line = read_stderr_line()
+            # TODO pretty print to stderr ?
+            sys.stderr.write(line)
+
+            # the line may not be valid json object
+            if line.startswith("{") and line.endswith("}\n"):
+                # TODO load the json line, add some other parameters like hostname, uuid, etc
+                # serialize again and send to nsq
+                # TODO check that it is a log
+
+                # NOTE for now just sending it across
+                self.write_to_nsq(line)
+
+            # FIXME is this a bottleneck ? only one log per 0.1 seconds ?
+            # consider threads http://eyalarubas.com/python-subproc-nonblock.html
+            time.sleep(0.1)
+
+        # read the remaining stderr
+        remaining = self.process.stderr.read()
+        sys.stderr.write(remaining)
+        sys.stderr.flush()
+
+        return self.process.returncode
 
 def parse_args():
+    # TODO accept configuration file
+
     parser = argparse.ArgumentParser(
         description="process wrapper",
     )
 
     parser.add_argument("-p", "--pid",
-        help="write the pid to file if present"
+        default=ProcessWrapper._PID_FILE,
+        help="write the pid to file if present, default: %(default)s"
+    )
+
+    # TODO should this be the other way around ? always disabled ?
+    parser.add_argument("--disable-nsq", action="store_true",
+        default=ProcessWrapper._DISABLE_NSQ,
+        help="to disable pushing to nsq, default: %(default)s",
+    )
+
+    parser.add_argument("--nsq-log-topic",
+        default=ProcessWrapper._NSQ_LOG_TOPIC,
+        help="nsq topic name for logs, default: %(default)s",
+    )
+
+    parser.add_argument("--nsqd-http-address",
+        default=ProcessWrapper._NSQD_HTTP_ADDRESS,
+        help="nsqd http address, default: %(default)s",
     )
 
     parser.add_argument("command", nargs=argparse.REMAINDER,
         help="the command to run",
     )
+
     args = parser.parse_args()
     if args.pid:
         args.pid = os.path.abspath(os.path.expanduser(args.pid))
@@ -43,7 +161,14 @@ def parse_args():
 
 def main():
     args = parse_args()
-    returncode = procwrap(args.command, pid_file=args.pid)
+    procwrap = ProcessWrapper(
+        args.command,
+        pid_file=args.pid,
+        disable_nsq=args.disable_nsq,
+        nsq_log_topic=args.nsq_log_topic,
+        nsqd_http_address=args.nsqd_http_address,
+    )
+    returncode = procwrap.start()
     sys.exit(returncode)
 
 if __name__ == '__main__':

--- a/procwrap/procwrap.py
+++ b/procwrap/procwrap.py
@@ -3,173 +3,102 @@
 import os
 import sys
 import time
+import json
 import requests
 import argparse
 import subprocess
 
-# what if this script fails somewhere.
-# say the nsq doesn't connect, etc.
-# we have to use local logging for this.
-import logging
-logging.basicConfig(
-    stream=sys.stderr,
-    datefmt="%Y-%m-%dT%H-%M-%S",
-    format="%(asctime)s %(name)s %(levelname)s %(message)s",
-)
-logger = logging.getLogger()
+from basescript import BaseScript
 
-class ProcessWrapper(object):
-    _NSQD_HTTP_ADDRESS = "http://127.0.0.1:4151"
-    _NSQ_LOG_TOPIC = "log"
-    _DISABLE_NSQ = False
-    _PID_FILE = None
+class ProcessWrapper(BaseScript):
+    DESC = "process wrapper"
 
-    def __init__(
-            self,
-            command,
-            pid_file=_PID_FILE,
-            disable_nsq=_DISABLE_NSQ,
-            nsq_log_topic=_NSQ_LOG_TOPIC,
-            nsqd_http_address=_NSQD_HTTP_ADDRESS):
-
-        self.command = command
-        self.pid_file = pid_file
-        self.disable_nsq = disable_nsq
-        self.nsq_log_topic = nsq_log_topic
-
-        nsqd_http_address = nsqd_http_address.rstrip('/')
-        if not nsqd_http_address.startswith("http://"):
-            nsqd_http_address = 'http://%s' % nsqd_http_address
-
-        self.nsqd_http_address = nsqd_http_address
-
-        self.process = None
+    def pre_run_init(self):
         self.write_to_nsq = lambda msg: None
+        self.process = None
 
-        if not self.disable_nsq:
-            self.init_nsq()
+        if not self.args.enable_nsq:
+            return
 
-    def init_nsq(self):
+        addr = self.args.nsqd_http_address
+        addr = addr.rstrip('/')
+        if not addr.startswith('http://'):
+            addr = 'http://%s' % addr
+
+        self.args.nsqd_http_address = addr
+
         session = requests.Session()
-        # TODO use urljoin ?
-        response = None
-        try:
-            response = session.get("%s/ping" % self.nsqd_http_address)
-            if response.status_code != 200:
-                raise Exception("bad response %s" % response)
-        except:
-            logger.exception(
-                "if you wish to disable nsqd, use --disable-nsq"
+        response = session.get('%s/ping') % addr
+        if response.status_code != 200:
+            raise Exception("bad response %s" % response)
+
+        url = '%s/ping' % self.args.nsqd_http_address
+        self.write_to_nsq = lambda msg: session.post(
+                url, data=msg, params={'topic': self.args.nsq_log_topic},
             )
-            sys.exit(-1)
 
-        # TODO nsq is a failure point for our logs. what do we do if nsq is down ?
+        self.log.info("pushing logs to nsq", url=url, topic=self.args.nsq_log_topic)
 
-        url = "%s/pub" % self.nsqd_http_address
-        topic = self.nsq_log_topic
-        # TODO what if this write to nsq fails ?
-        self.write_to_nsq = lambda msg: session.post(url, data=msg, params={"topic": topic})
+    def run(self):
+        self.pre_run_init()
+        self.log.info('starting process', command=self.args.command)
 
-    def start(self):
-        """
-        starts the command and blocks till it finishes.
-        once finished, returns the returncode.
-        """
-
-        if self.pid_file is not None:
-            d = os.path.dirname(self.pid_file)
-            if not os.path.exists(d):
-                os.makedirs(d)
-
-        # NOTE only capturing stderr. stdout still goes to tty.
-
+        # TODO atexit handler to kill this
         self.process = subprocess.Popen(
-            self.command, bufsize=1, universal_newlines=True,
+            self.args.command, bufsize=1, universal_newlines=True,
             stderr=subprocess.PIPE,
         )
 
-        if self.pid_file is not None:
-            with open(self.pid_file, "w") as fp:
-                fp.write("%s" % self.process.pid)
-
+        self.log.info("process started", pid=self.process.pid)
         read_stderr_line = self.process.stderr.readline
         poll = self.process.poll
-        # TODO buffering and sending many to nsq together ?
-        # TODO avoid
+
+        # TODO bufferring and sending many to nsq together
         while poll() is None:
             line = read_stderr_line()
-            # TODO pretty print to stderr ?
-            sys.stderr.write(line)
 
-            # the line may not be valid json object
-            if line.startswith("{") and line.endswith("}\n"):
-                # TODO load the json line, add some other parameters like hostname, uuid, etc
-                # serialize again and send to nsq
-                # TODO check that it is a log
+            try:
+                jline = json.loads(line)
+                # TODO check that it is really a log
+                # TODO send hostname, uuid, timestamp etc.
 
-                # NOTE for now just sending it across
+                # NOTE not using standard log levels because we want this to be transparent
+                level = jline.get("level", "debug")
+                event = jline.pop("event", "")
+                self.log._proxy_to_logger(level, event, **jline)
                 self.write_to_nsq(line)
 
-            # FIXME is this a bottleneck ? only one log per 0.1 seconds ?
-            # consider threads http://eyalarubas.com/python-subproc-nonblock.html
-            time.sleep(0.1)
+            except ValueError:
+                sys.stderr.write(line)
 
         # read the remaining stderr
         remaining = self.process.stderr.read()
+        # TODO this should be processed as well
         sys.stderr.write(remaining)
         sys.stderr.flush()
 
-        return self.process.returncode
+        sys.exit(self.process.returncode)
 
-def parse_args():
-    # TODO accept configuration file
+    def define_args(self, parser):
+        super(ProcessWrapper, self).define_args(parser)
+        parser.add_argument("--enable-nsq", action="store_true",
+            default=False,
+            help="push logs to nsq. default: %(default)s",
+        )
+        parser.add_argument("--nsq-log-topic", default="log",
+            help="nsq topic name for logs, default: %(default)s",
+        )
+        parser.add_argument("--nsqd-http-address",
+            default="http://127.0.0.1:4151",
+            help="nsqd http address, default: %(default)s",
+        )
 
-    parser = argparse.ArgumentParser(
-        description="process wrapper",
-    )
-
-    parser.add_argument("-p", "--pid",
-        default=ProcessWrapper._PID_FILE,
-        help="write the pid to file if present, default: %(default)s"
-    )
-
-    # TODO should this be the other way around ? always disabled ?
-    parser.add_argument("--disable-nsq", action="store_true",
-        default=ProcessWrapper._DISABLE_NSQ,
-        help="to disable pushing to nsq, default: %(default)s",
-    )
-
-    parser.add_argument("--nsq-log-topic",
-        default=ProcessWrapper._NSQ_LOG_TOPIC,
-        help="nsq topic name for logs, default: %(default)s",
-    )
-
-    parser.add_argument("--nsqd-http-address",
-        default=ProcessWrapper._NSQD_HTTP_ADDRESS,
-        help="nsqd http address, default: %(default)s",
-    )
-
-    parser.add_argument("command", nargs=argparse.REMAINDER,
-        help="the command to run",
-    )
-
-    args = parser.parse_args()
-    if args.pid:
-        args.pid = os.path.abspath(os.path.expanduser(args.pid))
-
-    return args
+        parser.add_argument("command", nargs=argparse.REMAINDER,
+            help="the command to run",
+        )
 
 def main():
-    args = parse_args()
-    procwrap = ProcessWrapper(
-        args.command,
-        pid_file=args.pid,
-        disable_nsq=args.disable_nsq,
-        nsq_log_topic=args.nsq_log_topic,
-        nsqd_http_address=args.nsqd_http_address,
-    )
-    returncode = procwrap.start()
-    sys.exit(returncode)
+    ProcessWrapper().start()
 
 if __name__ == '__main__':
     main()

--- a/procwrap/procwrap.py
+++ b/procwrap/procwrap.py
@@ -38,9 +38,21 @@ class ProcessWrapper(BaseScript):
 
 
         url = urljoin(self.args.nsqd_http_address, '/ping')
-        response = requests.get(url)
-        if response.status_code != 200:
-            raise Exception("bad response %s" % response)
+        retries = 0
+        while True:
+            try:
+                response = requests.get(url)
+                if response.status_code != 200:
+                    raise Exception("bad response %s" % response)
+                break
+
+            except:
+                retries += 1
+                self.log.exception("failed to ping nsqd")
+                if retries > 30:
+                    raise
+
+            time.sleep(60)
 
         # TODO make queuesize configurable
         queue = Queue.Queue(maxsize=1000)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(
     url="https://github.com/deep-compute/procwrap",
     download_url="https://github.com/deep-compute/procwrap/tarball/%s" % version,
     license='MIT License',
-    install_requires=[],
+    install_requires=[
+        "requests",
+    ],
     package_dir={'procwrap': 'procwrap'},
     packages=find_packages('.'),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     download_url="https://github.com/deep-compute/procwrap/tarball/%s" % version,
     license='MIT License',
     install_requires=[
+        "basescript",
         "requests",
     ],
     package_dir={'procwrap': 'procwrap'},


### PR DESCRIPTION
- made procwrap into ProcessWrapper
I imagine the complexity will be far more than a single function. With future addition of stats as well.
- ProcessWrapper sends json data on stderr to nsq through http
I tried using the tcp protocol, but felt it was overkill, with tornado or gevent clients. Apparently even bitly uses the http protocol most of the time. I'm hoping the overhead of http won't be that high, given the Session uses the same socket connection. Also, we can send multiple logs in the same nsq packet.

> What happens if nsq is down ?